### PR TITLE
remove trailing slash from Stata project paths

### DIFF
--- a/waflib/extras/write_project_headers.py
+++ b/waflib/extras/write_project_headers.py
@@ -336,13 +336,13 @@ class WriteProjectPathsStata(Task.Task):
     def _write_ado_paths(self, ado_paths, out_file):
         for name, val in ado_paths.items():
             if re.match('PERSONAL|PLUS', name):
-                out_file.write('sysdir set {} "{}/"\n'.format(
+                out_file.write('sysdir set {} "{}"\n'.format(
                     name,
                     val.abspath())
                 )
             else:
-                out_file.write('adopath ++ "{}/"\n'.format(val.abspath()))
-                out_file.write('adopath ++ "{}/"\n'.format(
+                out_file.write('adopath ++ "{}"\n'.format(val.abspath()))
+                out_file.write('adopath ++ "{}"\n'.format(
                     val.get_bld().abspath())
                 )
         out_file.write('\n')
@@ -354,7 +354,7 @@ class WriteProjectPathsStata(Task.Task):
                 val = self.env.PROJECT_PATHS[name]
                 if isinstance(val, Node.Node):
                     out_file.write(
-                        'global PATH_{n} "{p}/"\n'.format(
+                        'global PATH_{n} "{p}"\n'.format(
                             n=name,
                             p=val.abspath()
                         )


### PR DESCRIPTION
This couldn't possibly matter less other than for aesthetic reasons, but `WriteProjectPathsStata()` generates paths with trailing slashes, which means that when you then do

    do `"${PATH_OUT_MODEL_SPECS}/geography"'

in a Stata do-file, this gets interpolated to

    do /.../.../econ-project-templates-stata/out/src/model_specs//geography

(note the two slashes in the path).