### PR TITLE
Link to waf was at code.google

### DIFF
--- a/waf.html
+++ b/waf.html
@@ -159,7 +159,7 @@
             
   <div class="section" id="introduction-to-waf">
 <span id="waf-intro"></span><h1>Introduction to Waf<a class="headerlink" href="#introduction-to-waf" title="Permalink to this headline">¶</a></h1>
-<p><a class="reference external" href="https://code.google.com/p/waf/">Waf</a> is our tool of choice to automate the dependency tracking via a DAG (directed acyclic graph) structure. Written in Python and originally designed to build software, it directly extends to our purposes. You find the program in the root folder of the project template (the file <em>waf.py</em> and the hidden folder <em>.mywaflib</em>). The settings for a particular project are controlled via files called <em>wscript</em>, which are kept in the root directory (required) and usually in the directories close to the tasks that need to be performed.</p>
+<p><a class="reference external" href="https://waf.io/">Waf</a> is our tool of choice to automate the dependency tracking via a DAG (directed acyclic graph) structure. Written in Python and originally designed to build software, it directly extends to our purposes. You find the program in the root folder of the project template (the file <em>waf.py</em> and the hidden folder <em>.mywaflib</em>). The settings for a particular project are controlled via files called <em>wscript</em>, which are kept in the root directory (required) and usually in the directories close to the tasks that need to be performed.</p>
 <p>There are three phases to building a project:</p>
 <blockquote>
 <div><ul class="simple">


### PR DESCRIPTION
now at waf.io (there is also https://github.com/waf-project/waf, but the main page seemed more appropriate, just change as needed)